### PR TITLE
Add OSX to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ rust:
   - beta
   - nightly
 cache: cargo
+os:
+  - linux
+  - osx


### PR DESCRIPTION
Travis builds on Linux by default, and this change effectively just adds OS X/macOS.
